### PR TITLE
Changes from double to single quotes for id_string

### DIFF
--- a/inc/class-sb-instagram-feed.php
+++ b/inc/class-sb-instagram-feed.php
@@ -386,7 +386,7 @@ class SB_Instagram_Feed
 		if ( is_array( $num_or_array_of_ids ) ) {
 			$ids = $num_or_array_of_ids;
 
-			$id_string = '"' . implode( '","', $ids ) . '"';
+			$id_string = "'" . implode( "','", $ids ) . "'";
 			$results = $wpdb->get_results( $wpdb->prepare( "
 			SELECT p.media_id, p.instagram_id, p.aspect_ratio, p.sizes
 			FROM $posts_table_name AS p 


### PR DESCRIPTION
When imploding ids in get_resized_images_source_set() to create a string to be used in a SQL-query double quotes are used which result in a SQL-error complaning about "No such column".


Fixes #59